### PR TITLE
edit: updating contact to support e-mail

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -6,7 +6,7 @@
 
 If there are any vulnerabilities in this repository, don't hesitate to _report them_.
 
-Please email security@readme.io and describe what you've found.
+Please email support@readme.io and describe what you've found.
 
 - If you have a fix, explain or attach it.
 - In the near time, expect a reply with the required steps. Also, there may be a demand for a pull request which include the fixes.


### PR DESCRIPTION
we can change this (or ignore this PR) if we have route security@ back to support@

## 🧰 Changes

Changing e-mail (temporarily) to route to the correct place.

Right now it's being routed to HackerOne:

`ReadMe (via HackerOne) <no-reply@hackerone.com> `
