### PR TITLE
docs: create SUPPORT.md

### DIFF
--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -13,3 +13,5 @@ The fastest way to get a response is if you contact us via Intercom. You can rea
 ### Issues With This Repository
 
 Please read our [security policy](./SECURITY.md) for information on reporting security vulnerabilities. If you have any other kind of bug report, a feature request, or a question that is specific to this repository, please create a new issue.
+
+We look forward to hearing from you! :owl:

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,15 @@
+# Contacting Us
+
+<img align="right" width="25%" style="margin-bottom: 2em" src="https://owlbert.io/images/owlberts-png/Doctor.psd.png">
+
+### General Support
+
+Need help with your OpenAPI definition, our API, or the ReadMe platform in general?
+
+The best way to get in touch is to contact #supportivepeople, AKA the most supportive people at ReadMe, AKA our support team!
+
+The fastest way to get a response is if you contact us via Intercom. You can read more about how to do this [in our docs](https://docs.readme.com/docs/contact-support). You can also email us at support@readme.io.
+
+### Issues With This Repository
+
+Please read our [security policy](./SECURITY.md) for information on reporting security vulnerabilities. If you have any other kind of bug report or a feature request that is specific to this repository, feel free to create a new issue.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -12,4 +12,4 @@ The fastest way to get a response is if you contact us via Intercom. You can rea
 
 ### Issues With This Repository
 
-Please read our [security policy](./SECURITY.md) for information on reporting security vulnerabilities. If you have any other kind of bug report or a feature request that is specific to this repository, feel free to create a new issue.
+Please read our [security policy](./SECURITY.md) for information on reporting security vulnerabilities. If you have any other kind of bug report, a feature request, or a question that is specific to this repository, please create a new issue.


### PR DESCRIPTION
## 🧰 Changes

The purpose of this doc is to provide information on how to get support with a given repository. Since this doc is in a special `.github` repository, so it will show up for **all** of our organization's repositories. In other words, if someone creates an issue in any one of our organization's repositories, a link to this doc will appear on the side.

Read more about how GitHub surfaces this info here: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project

Fixes #2 

## 🧬 QA & Testing

Does this doc look good?
