### PR TITLE
feat: creating a starter workflow for browser testing

### DIFF
--- a/.github/workflow-templates/browser-testing.properties.json
+++ b/.github/workflow-templates/browser-testing.properties.json
@@ -1,0 +1,10 @@
+{
+  "name": "Browser Testing",
+  "description": "Mocha + Chai + Karma browser testing starter workflow",
+  "categories": [
+    "JavaScript"
+  ],
+  "filePatterns": [
+    "package.json$"
+  ]
+}

--- a/.github/workflow-templates/browser-testing.properties.json
+++ b/.github/workflow-templates/browser-testing.properties.json
@@ -1,6 +1,6 @@
 {
   "name": "Browser Testing",
-  "description": "Mocha + Chai + Karma browser testing starter workflow",
+  "description": "Mocha + Chai + Karma browser testing starter workflow. To use this workflow you will need to have `chai`, `mocha`, `@jsdevtools/host-environment`, and `@jsdevtools/karma-config` installed, along with a `karma.config.js` file set up. Check out the [Karma config in `fetch-har`](https://github.com/readmeio/fetch-har/blob/main/karma.conf.js) for an example of how to set this up.",
   "categories": [
     "JavaScript"
   ],

--- a/.github/workflow-templates/browser-testing.yml
+++ b/.github/workflow-templates/browser-testing.yml
@@ -1,0 +1,63 @@
+name: Browser Testing
+
+on: [push]
+
+jobs:
+  run:
+    name: Browser
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        browser:
+          - chrome
+          - firefox
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install npm@8
+        run: npm install -g npm@8
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Chrome
+      - uses: browser-actions/setup-chrome@latest
+        if: matrix.browser == 'chrome'
+
+      - name: Run tests on Chrome
+        if: matrix.browser == 'chrome'
+        run: |
+          npm run test:browser -- --browsers=ChromeHeadless
+
+      # Firefox
+      - uses: browser-actions/setup-chrome@latest
+        if: matrix.browser == 'firefox'
+
+      - name: Run tests on Firefox
+        if: matrix.browser == 'firefox'
+        run: |
+          npm run test:browser -- --browsers=FirefoxHeadless

--- a/.github/workflow-templates/browser-testing.yml
+++ b/.github/workflow-templates/browser-testing.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(npm config get cache)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: npm-cache
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}

--- a/.github/workflow-templates/browser-testing.yml
+++ b/.github/workflow-templates/browser-testing.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node
         uses: actions/setup-node@v3

--- a/.github/workflow-templates/browser-testing.yml
+++ b/.github/workflow-templates/browser-testing.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -37,9 +37,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-
-      - name: Install npm@8
-        run: npm install -g npm@8
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
| 🚥 Fix https://github.com/readmeio/oas-to-har/pull/78#discussion_r856377247 |
| :-- |

## 🧰 Changes

This copies across the Mocha + Chai + Karma browser testing workflow I've been building in `fetch-har` and `oas-to-har` into here so we can easily carry it to other projects.

https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization
https://github.com/readmeio/oas-to-har/pull/78
